### PR TITLE
Convert to paginated data table and moved add expense control to app bar

### DIFF
--- a/lib/components/home/home.dart
+++ b/lib/components/home/home.dart
@@ -1,4 +1,5 @@
 import 'package:expense_manager/components/navbar/bottom_navbar.dart';
+import 'package:expense_manager/pages/add_expense.dart';
 import 'package:expense_manager/pages/settings.dart';
 import 'package:expense_manager/providers/expense_provider.dart';
 import 'package:expense_manager/utils/database_config_store/database_config_store.dart';
@@ -95,10 +96,22 @@ class _HomeState extends State<Home> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leading: IconButton.filledTonal(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add Expense',
+            onPressed: () {
+              Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const AddExpensePage()));
+            }),
         actions: [
-          IconButton(
-              onPressed: navigateToSettingsPage,
-              icon: const Icon(Icons.settings))
+          Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+            IconButton(
+                tooltip: 'Database Settings',
+                onPressed: navigateToSettingsPage,
+                icon: const Icon(Icons.settings))
+          ])
         ],
       ),
       body: _isLoading

--- a/lib/components/navbar/navbar_page.dart
+++ b/lib/components/navbar/navbar_page.dart
@@ -1,4 +1,3 @@
-import 'package:expense_manager/pages/add_expense.dart';
 import 'package:flutter/material.dart';
 
 class NavbarPage extends StatelessWidget {
@@ -10,13 +9,6 @@ class NavbarPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: body,
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(context,
-              MaterialPageRoute(builder: (context) => const AddExpensePage()));
-        },
-        child: const Icon(Icons.add),
-      ),
     );
   }
 }

--- a/lib/data_sources/expense_data_source.dart
+++ b/lib/data_sources/expense_data_source.dart
@@ -1,0 +1,86 @@
+import 'package:data_table_2/data_table_2.dart';
+import 'package:expense_manager/data/expense_data.dart';
+import 'package:expense_manager/pages/edit_expense.dart';
+import 'package:expense_manager/providers/expense_provider.dart';
+import 'package:expense_manager/utils/logger/logger.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+class ExpenseDataSource extends DataTableSource {
+  final BuildContext context;
+  late List<ExpenseData> _expenseData;
+
+  ExpenseDataSource(this.context) {
+    final expenseProvider = Provider.of<ExpenseProvider>(context);
+    _expenseData = expenseProvider.expenses;
+  }
+
+  @override
+  DataRow2? getRow(int index) {
+    final expenseProvider = Provider.of<ExpenseProvider>(context);
+    ExpenseData expense = _expenseData[index];
+    return DataRow2(
+      cells: <DataCell>[
+        DataCell(Text(DateFormat('MM/dd/yyyy').format(expense.date))),
+        DataCell(Text(expense.description)),
+        DataCell(Text(expense.category)),
+        DataCell(Text(expense.person)),
+        DataCell(Text(NumberFormat.simpleCurrency().format(expense.cost))),
+      ],
+      onDoubleTap: () => Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (context) => EditExpensePage(expense: expense))),
+      onLongPress: () => showDialog<void>(
+          context: context,
+          barrierDismissible: true,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text('Delete Expense'),
+              content: const Text('Are you sure?'),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    expenseProvider.deleteExpense(expense).then((_) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Expense deleted!'),
+                          backgroundColor: Color.fromARGB(255, 0, 95, 0),
+                        ),
+                      );
+                      Navigator.of(context).pop();
+                    }).catchError((e) {
+                      logger.e(e);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Failed to delete expense :('),
+                          backgroundColor: Color.fromARGB(255, 95, 0, 0),
+                        ),
+                      );
+                    });
+                  },
+                  child: const Text(
+                    'Delete',
+                    selectionColor: Color.fromARGB(255, 95, 0, 0),
+                  ),
+                ),
+              ],
+            );
+          }),
+    );
+  }
+
+  @override
+  bool get isRowCountApproximate => false;
+
+  @override
+  int get rowCount => _expenseData.length;
+
+  @override
+  int get selectedRowCount => 0;
+}

--- a/lib/pages/expenses.dart
+++ b/lib/pages/expenses.dart
@@ -1,10 +1,8 @@
 import 'package:data_table_2/data_table_2.dart';
 import 'package:expense_manager/data/expense_data.dart';
-import 'package:expense_manager/utils/logger/logger.dart';
-import 'package:expense_manager/pages/edit_expense.dart';
+import 'package:expense_manager/data_sources/expense_data_source.dart';
 import 'package:expense_manager/providers/expense_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class ExpensePage extends StatefulWidget {
@@ -30,6 +28,7 @@ class _ExpensePageState extends State<ExpensePage> {
   @override
   Widget build(BuildContext context) {
     final expenseProvider = Provider.of<ExpenseProvider>(context);
+    int rowsPerPage = 10;
 
     void sort<T>(
       Comparable<T> Function(ExpenseData d) getField,
@@ -43,124 +42,73 @@ class _ExpensePageState extends State<ExpensePage> {
       });
     }
 
-    List<DataRow2> generateDataRows() {
-      List<DataRow2> dataRows = [];
-      for (var e in expenseProvider.expenses) {
-        dataRows.add(DataRow2(
-          cells: <DataCell>[
-            DataCell(Text(DateFormat('MM/dd/yyyy').format(e.date))),
-            DataCell(Text(e.description)),
-            DataCell(Text(e.category)),
-            DataCell(Text(e.person)),
-            DataCell(Text(NumberFormat.simpleCurrency().format(e.cost))),
-          ],
-          onDoubleTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                  builder: (context) => EditExpensePage(expense: e))),
-          onLongPress: () => showDialog<void>(
-              context: context,
-              barrierDismissible: true,
-              builder: (BuildContext context) {
-                return AlertDialog(
-                  title: const Text('Delete Expense'),
-                  content: const Text('Are you sure?'),
-                  actions: <Widget>[
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: const Text('Cancel'),
-                    ),
-                    TextButton(
-                      onPressed: () {
-                        expenseProvider.deleteExpense(e).then((_) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Expense deleted!'),
-                              backgroundColor: Color.fromARGB(255, 0, 95, 0),
-                            ),
-                          );
-                          Navigator.of(context).pop();
-                        }).catchError((e) {
-                          logger.e(e);
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Failed to delete expense :('),
-                              backgroundColor: Color.fromARGB(255, 95, 0, 0),
-                            ),
-                          );
-                        });
-                      },
-                      child: const Text(
-                        'Delete',
-                        selectionColor: Color.fromARGB(255, 95, 0, 0),
-                      ),
-                    ),
-                  ],
-                );
-              }),
-        ));
-      }
-      return dataRows;
-    }
-
     return SafeArea(
         child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: DataTable2(
-                showBottomBorder: true,
-                sortColumnIndex: sortColumnIndex,
-                sortAscending: sortAscending,
-                sortArrowIcon: Icons.keyboard_arrow_up,
-                sortArrowAnimationDuration: const Duration(milliseconds: 500),
-                scrollController: controller,
-                horizontalScrollController: horizontalController,
-                minWidth: 900,
-                isVerticalScrollBarVisible: true,
-                isHorizontalScrollBarVisible: true,
-                empty: Center(
-                    child: Container(
-                        padding: const EdgeInsets.all(20),
-                        decoration: BoxDecoration(
-                            color:
-                                Theme.of(context).colorScheme.primaryContainer,
-                            border: Border.all(
-                                width: 2.0,
-                                color: Theme.of(context).colorScheme.primary),
-                            borderRadius: BorderRadius.circular(10)),
-                        child: const Text('No data'))),
-                columns: [
-                  DataColumn2(
-                    label: const Text('Date'),
-                    size: ColumnSize.S,
-                    onSort: (columnIndex, ascending) =>
-                        sort<DateTime>((d) => d.date, columnIndex, ascending),
-                  ),
-                  DataColumn2(
-                    label: const Text('Description'),
-                    size: ColumnSize.S,
-                    onSort: (columnIndex, ascending) => sort<String>(
-                        (d) => d.description, columnIndex, ascending),
-                  ),
-                  DataColumn2(
-                    label: const Text('Category'),
-                    size: ColumnSize.S,
-                    onSort: (columnIndex, ascending) =>
-                        sort<String>((d) => d.category, columnIndex, ascending),
-                  ),
-                  DataColumn2(
-                    label: const Text('Owner'),
-                    size: ColumnSize.S,
-                    onSort: (columnIndex, ascending) =>
-                        sort<String>((d) => d.person, columnIndex, ascending),
-                  ),
-                  DataColumn2(
-                    label: const Text('Cost'),
-                    size: ColumnSize.S,
-                    numeric: true,
-                    onSort: (columnIndex, ascending) =>
-                        sort<num>((d) => d.cost, columnIndex, ascending),
-                  ),
-                ],
-                rows: generateDataRows())));
+      padding: const EdgeInsets.all(5),
+      child: PaginatedDataTable2(
+        source: ExpenseDataSource(context),
+        sortColumnIndex: sortColumnIndex,
+        sortAscending: sortAscending,
+        sortArrowIcon: Icons.keyboard_arrow_up,
+        sortArrowAnimationDuration: const Duration(milliseconds: 500),
+        scrollController: controller,
+        horizontalScrollController: horizontalController,
+        minWidth: 900,
+        isVerticalScrollBarVisible: true,
+        isHorizontalScrollBarVisible: true,
+        availableRowsPerPage: const [10, 50],
+        rowsPerPage: rowsPerPage,
+        onRowsPerPageChanged: (int? value) {
+          setState(() {
+            rowsPerPage = value ?? rowsPerPage;
+          });
+        },
+        columnSpacing: 0,
+        renderEmptyRowsInTheEnd: false,
+        empty: Center(
+            child: Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    border: Border.all(
+                        width: 2.0,
+                        color: Theme.of(context).colorScheme.primary),
+                    borderRadius: BorderRadius.circular(10)),
+                child: const Text('No data'))),
+        columns: [
+          DataColumn2(
+            label: const Text('Date'),
+            size: ColumnSize.S,
+            onSort: (columnIndex, ascending) =>
+                sort<DateTime>((d) => d.date, columnIndex, ascending),
+          ),
+          DataColumn2(
+            label: const Text('Description'),
+            size: ColumnSize.S,
+            onSort: (columnIndex, ascending) =>
+                sort<String>((d) => d.description, columnIndex, ascending),
+          ),
+          DataColumn2(
+            label: const Text('Category'),
+            size: ColumnSize.S,
+            onSort: (columnIndex, ascending) =>
+                sort<String>((d) => d.category, columnIndex, ascending),
+          ),
+          DataColumn2(
+            label: const Text('Owner'),
+            size: ColumnSize.S,
+            onSort: (columnIndex, ascending) =>
+                sort<String>((d) => d.person, columnIndex, ascending),
+          ),
+          DataColumn2(
+            label: const Text('Cost'),
+            size: ColumnSize.S,
+            numeric: true,
+            onSort: (columnIndex, ascending) =>
+                sort<num>((d) => d.cost, columnIndex, ascending),
+          ),
+        ],
+      ),
+    ));
   }
 }


### PR DESCRIPTION
This change is to accommodate a large number of transaction entries. This PR also moves the add expense button to the main page app bar as it was covering up some pagination controls on the expenses tab.

Closes #17.